### PR TITLE
form button

### DIFF
--- a/src/Spatie/Payment/Gateways/Europabank/form.blade.php
+++ b/src/Spatie/Payment/Gateways/Europabank/form.blade.php
@@ -28,7 +28,7 @@
     {{ Form::hidden('Emailfrom', Config::get('payment::europabank.secondChanceEmailSender')) }}
 @endif
 
-{{ Form::submit(Lang::get('payment::form.submitButtonText')) }}
+{{ Form::button(Lang::get('payment::form.submitButtonText'),[type="submit"]) }}
 
 
 </form>


### PR DESCRIPTION
The button[type=submit] gives more styling freedom on this submit button - compared to the traditional input[type=submit} button.
